### PR TITLE
Fixed: Kazoo returns node children as Unicode.

### DIFF
--- a/src/zc/zk/README.txt
+++ b/src/zc/zk/README.txt
@@ -207,7 +207,7 @@ but you can still update data.
 
     >>> p2 = zk.properties('/fooservice', watch=False)
     >>> sorted(p2)
-    ['secret', 'threads']
+    [u'secret', u'threads']
     >>> p2(lambda data: None)
     Traceback (most recent call last):
     ...
@@ -544,7 +544,7 @@ the exported tree.
 Now, we'll create a databases node::
 
     >>> zk.create('/databases')
-    '/databases'
+    u'/databases'
 
 And import the export::
 
@@ -992,7 +992,7 @@ You can also get a mutable list of children, which you can mutate:
     >>> i = zk.walk('/fooservice', children=True)
     >>> path, children = i.next()
     >>> path, children
-    ('/fooservice', ['providers', 'provision'])
+    ('/fooservice', [u'providers', u'provision'])
 
     >>> del children[0]
     >>> for path in i:
@@ -1250,6 +1250,14 @@ more, use the help function::
 
 Change History
 ==============
+
+Fixed: Kazoo returns node children as Unicode.
+       zc.zk client applications expect children as
+       returned by the children to have bytes values and
+       they use the values to connect sockets.
+
+       ``Children`` objects returned by zc.zk.children now encode
+       child names using UTF-8.
 
 2.0.0a4 (2014-01-13)
 --------------------

--- a/src/zc/zk/__init__.py
+++ b/src/zc/zk/__init__.py
@@ -489,6 +489,9 @@ class Children(Watch):
 
     children = True
 
+    def setData(self, data):
+        Watch.setData(self, [v.encode('utf8') for v in data])
+
     def __len__(self):
         return len(self.data)
 

--- a/src/zc/zk/ephemeral_node_recovery_on_session_reestablishment.test
+++ b/src/zc/zk/ephemeral_node_recovery_on_session_reestablishment.test
@@ -14,14 +14,14 @@ reestablishment:
 So, we have an ephemeral node before losing the session:
 
     >>> zk.get_children('/fooservice/providers')
-    ['test']
+    [u'test']
 
     >>> zk.client.lose_session()
 
 Now, after creating the new session, we have the ephemeral node:
 
     >>> zk.get_children('/fooservice/providers')
-    ['test']
+    [u'test']
 
 Some custom data and acl:
 

--- a/src/zc/zk/testing.py
+++ b/src/zc/zk/testing.py
@@ -462,12 +462,15 @@ class ZooKeeper:
             return self._check_handle(handle, False).state
 
     def create(self, handle, path, data, acl, ephemeral=False):
+        if isinstance(path, str):
+            path = path.decode('utf8')
+        while path.endswith(u'/'):
+            path = path[:-1]
+        base, name = path.rsplit(u'/', 1)
+
         with self.lock:
             self._check_handle(handle)
-            while path.endswith('/'):
-                path = path[:-1]
-            base, name = path.rsplit('/', 1)
-            node = self._traverse(base or '/')
+            node = self._traverse(base or u'/')
             if name in node.children:
                 raise kazoo.exceptions.NodeExistsError()
             node.children[name] = newnode = Node(data)
@@ -481,6 +484,8 @@ class ZooKeeper:
             return path
 
     def ensure_path(self, handle, path, acl):
+        if isinstance(path, str):
+            path = path.decode('utf8')
         while path.endswith('/'):
             path = path[:-1]
         if not path:

--- a/src/zc/zk/tests.py
+++ b/src/zc/zk/tests.py
@@ -1065,7 +1065,7 @@ Closing doesn't close the client:
     >>> zk.close()
 
     >>> sorted(client.get_children('/'))
-    ['fooservice', 'zookeeper']
+    [u'fooservice', u'zookeeper']
 
     >>> client.stop()
     >>> client.close()
@@ -1127,7 +1127,6 @@ checker = zope.testing.renormalizing.RENormalizing([
     (re.compile("{'pid': \d+}"), 'pid = 9999'),
     (re.compile('/zc\.zk\.testing\.test-root\d+'), ''),
     (re.compile(r'2 None\n4 None'), '4 None\n2 None'),
-    (re.compile(r"u'(/?\w)"), r"'\1"),
     ])
 
 def test_suite():


### PR DESCRIPTION
```
   zc.zk client applications expect children as
   returned by the children to have bytes values and
   they use the values to connect sockets.

   ``Children`` objects returned by zc.zk.children now encode
   child names using UTF-8.

   Also fixed the testing mock to behave more like kazoo in this
   respect.
```
