### PR TITLE
Fixed: zc.zk 2 didn't accept a value of None for session_timeout

### DIFF
--- a/src/zc/zk/README.txt
+++ b/src/zc/zk/README.txt
@@ -1259,6 +1259,9 @@ Fixed: Kazoo returns node children as Unicode.
        ``Children`` objects returned by zc.zk.children now encode
        child names using UTF-8.
 
+Fixed: zc.zk 2 didn't accept a value of None for session_timeout
+       constructor argument, breaking some old clients.
+
 2.0.0a4 (2014-01-13)
 --------------------
 

--- a/src/zc/zk/__init__.py
+++ b/src/zc/zk/__init__.py
@@ -115,8 +115,11 @@ class ZooKeeper(Resolving):
     def __init__(
         self,
         connection_string="127.0.0.1:2181",
-        session_timeout=10.0,
+        session_timeout=None,
         ):
+
+        if session_timeout is None:
+            session_timeout = 10.0
 
         if isinstance(connection_string, basestring):
             client = kazoo.client.KazooClient(

--- a/src/zc/zk/disconnectiontests.py
+++ b/src/zc/zk/disconnectiontests.py
@@ -95,3 +95,10 @@ Now, if we make changes, they'll be properly reflected:
 
     >>> zk.close()
     """
+
+def can_pass_None_for_session_timeout(): # here cuz must be used w mock :)
+    """
+    >>> zk = zc.zk.ZooKeeper('zookeeper.example.com:2181', None)
+    >>> zk.client.timeout
+    10.0
+    """


### PR DESCRIPTION
```
   constructor argument, breaking some old clients.
```
